### PR TITLE
append widget id to ga event send

### DIFF
--- a/src/pathfora.js
+++ b/src/pathfora.js
@@ -1247,11 +1247,13 @@
       }
 
       if (typeof ga === 'function') {
+        var gaLabel = data['pf-widget-action'] || data['pf-widget-event']
+
         ga(
           'send',
           'event',
           'Lytics',
-          data['pf-widget-action'] || data['pf-widget-event'],
+          data['pf-widget-id'] + ' : ' + gaLabel,
           '',
           {
             nonInteraction: true

--- a/test/pathforaSpec.js
+++ b/test/pathforaSpec.js
@@ -12,7 +12,7 @@ describe('Pathfora', function () {
   beforeEach(function() {
     localStorage.clear();
     pathfora.clearAll();
-  });    
+  });
 
   it('should track current time spent on page with 1 second accuracy', function () {
     jasmine.clock().install();
@@ -145,8 +145,8 @@ describe('Pathfora', function () {
       'pf-widget-variant': '1',
       'pf-widget-event': 'show'
     }));
-    
-    expect(ga).toHaveBeenCalledWith('send', 'event', 'Lytics', 'show', jasmine.any(String), jasmine.any(Object));
+
+    expect(ga).toHaveBeenCalledWith('send', 'event', 'Lytics',  messageBar.id + ' : show', jasmine.any(String), jasmine.any(Object));
 
     pathfora.clearAll();
     jasmine.Ajax.uninstall();
@@ -176,8 +176,8 @@ describe('Pathfora', function () {
       'pf-widget-variant': '1',
       'pf-widget-event': 'close'
     }));
-    
-    expect(ga).toHaveBeenCalledWith('send', 'event', 'Lytics', 'close', jasmine.any(String), jasmine.any(Object));
+
+    expect(ga).toHaveBeenCalledWith('send', 'event', 'Lytics', messageBar.id + ' : close', jasmine.any(String), jasmine.any(Object));
 
     pathfora.clearAll();
     jasmine.clock().uninstall();
@@ -591,7 +591,7 @@ describe('Widgets', function () {
       position: 'top-left',
       msg: 'custom color button',
       id: 'custom-widget',
-      theme: 'custom'                  
+      theme: 'custom'
     });
 
     var config =  {
@@ -600,7 +600,7 @@ describe('Widgets', function () {
           background: '#fff'
         }
       }
-    };                
+    };
 
     var w4 = new pathfora.Message({
       layout: 'button',
@@ -658,8 +658,8 @@ describe('Widgets', function () {
     });
 
     var config =  {
-      generic: { 
-        colors: { 
+      generic: {
+        colors: {
           background: '#eee',
           header: '#333',
           text: '#333',
@@ -670,7 +670,7 @@ describe('Widgets', function () {
           cancelBackground: '#eee'
         }
       }
-    };  
+    };
 
 
     pathfora.initializeWidgets([modal], credentials,config);
@@ -975,7 +975,7 @@ describe('API', function () {
       id: 'custom-button-text-test',
       layout: 'modal',
       msg: 'Custom button text test',
-      header: 'Hello',            
+      header: 'Hello',
       okMessage: 'Confirm',
       cancelMessage: 'Cancel'
     });
@@ -997,7 +997,7 @@ describe('API', function () {
       id: 'custom-random-test',
       layout: 'random',
       msg: 'Custom random layout test',
-      header: 'Hello'           
+      header: 'Hello'
     });
 
     pathfora.initializeWidgets([random],credentials);
@@ -1006,10 +1006,10 @@ describe('API', function () {
 
     expect(widget.find('.pf-widget-slideout')).toBeTruthy();
     expect(widget.find('.pf-position-right')).toBeTruthy();
-    expect(widget.find('.pf-widget-variant-2')).toBeTruthy();       
+    expect(widget.find('.pf-widget-variant-2')).toBeTruthy();
 
   });
-  
+
   it('should report to Google Analytics API, when available', function (done) {
     var messageBar = pathfora.Message({
       layout: 'modal',
@@ -1029,14 +1029,14 @@ describe('API', function () {
 
       expect(ga).toHaveBeenCalled();
       expect(ga.calls.mostRecent().args).toEqual([
-        'send', 
-        'event', 
-        'Lytics', 
-        messageBar.confirmAction.name,
-        jasmine.any(String), 
+        'send',
+        'event',
+        'Lytics',
+        messageBar.id + ' : ' + messageBar.confirmAction.name,
+        jasmine.any(String),
         jasmine.any(Object)
       ]);
-      
+
       done();
     }, 200);
   });


### PR DESCRIPTION
as it stood there was no way to differentiate which modal was reporting to google. by appending the id users can get a better understanding of what is working / what is not.