### PR TITLE
Actually add class from className

### DIFF
--- a/src/pathfora.js
+++ b/src/pathfora.js
@@ -1177,7 +1177,8 @@
         ' pf-widget-' + config.layout,
         config.position ? ' pf-position-' + config.position : '',
         ' pf-widget-variant-' + config.variant,
-        config.theme ? ' pf-theme-' + config.theme : ''
+        config.theme ? ' pf-theme-' + config.theme : '',
+        config.className ? ' ' + config.className : '',
       ].join('');
     },
 
@@ -1514,10 +1515,6 @@
         throw new Error('Config object is missing');
       }
 
-      if (!config.msg) {
-        throw new Error('Widget message is missing');
-      }
-
       if(config.layout === 'random') {
         props = {
           layout: ['modal', 'slideout', 'bar', 'folding'],
@@ -1582,7 +1579,7 @@
       if (!config.id &&
            config.displayConditions &&
            typeof config.displayConditions.hideAfterAction !== 'undefined') {
-        delete config.displayConditions.impressions;
+        delete config.displayConditions.hideAfterAction;
 
         throw new Error('Widgets with the hideAfterAction displayConditions need a preset id value. Display condition denied.');
       }

--- a/test/pathforaSpec.js
+++ b/test/pathforaSpec.js
@@ -882,14 +882,8 @@ describe('Widgets', function () {
       pathfora.initializeWidgets([promoWidget], credentials);
     };
 
-    var missingMessage = function () {
-      var promoWidget = new pathfora.Message({layout: 'modal'});
-      pathfora.initializeWidgets([promoWidget], credentials);
-    };
-
     expect(missingParams).toThrow(new Error('Config object is missing'));
     pathfora.clearAll();
-    expect(missingMessage).toThrow(new Error('Widget message is missing'));
   });
 
 


### PR DESCRIPTION
A couple things I came across while working on the getty modal:

`className` didn't actually work (there was no way to add a custom class to a widget)

I also didn't like the fact that we were preemptively checking for a widget message. For example with getty we have an A/B test where the two modals are exactly the same except for the confirm button text. I couldn't set the message in the config object, which means I'd have to be setting it twice in both modal object, for example:

```js
var config = {
  message: {
    layout: "slideout",
    msg: "a message",
  }
}

var modal = new pathfora.Message({
  okMessage: "yay",
});

var modal = new pathfora.Message({
  okMessage: "blah",
});
```
that resulted in the error "Widget message is missing". I think we should allow msg to be set in the config, so I removed that check.