### PR TITLE
Add guard to prevent instanbul instrumentation for prod build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
   - 8.2.1
+script:
+  - npm run prod
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)
+  

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ Gulp tasks:
   }
   ```
 
+Useful NPM scripts:
+
+- **`npm test`** - builds and activates Karma test runner on PhantomJS.
+
+- **`npm run clean`** - blow out the `./dist` folder. 
+
+- **`npm run build:prod`** - sets `NODE_ENV` to `production` and builds minified files in `./dist` folder.
+
+- **`npm run prod`** - run tests, clean and rebuild the `/dist` folder. This is built on top of the `gulp build`
+command. Important to know that this sets the `NODE_ENV` to `production`, removing instabul instrumentation for code coverage. Currently, this is the default command used for our Travis CI.
+
 ### Documentation
 Documentation for the most recent release is available [here](http://lytics.github.io/pathforadocs/).
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -100,14 +100,21 @@ var prepareTemplates = function () {
   return str.replace(/\"/g, '\'');
 };
 
+//Plugins for rollup. Babel, istanbul, etc.
+var rollupPlugins = [];
+
+if (process.env.NODE_ENV !== 'production') {
+  rollupPlugins.push(
+    istanbul({
+      exclude: ['test/*.spec.js', 'dist/*.js']
+    })
+  );
+}
+
 gulp.task('build:rollup', function () {
   return rollup.rollup({
     entry: 'src/rollup/pathfora.js',
-    plugins: [
-      istanbul({
-        exclude: ['test/*.spec.js', 'dist/*.js']
-      })
-    ]
+    plugins: rollupPlugins
   }).then(function (bundle) {
     bundle.write({
       format: 'iife',

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   },
   "scripts": {
     "test": "gulp build && karma start --single-run --browsers PhantomJS",
+    "clean": "rm -rf ./dist",
+    "build:prod": "NODE_ENV=production gulp build",
+    "prod": "npm run test && npm run clean && npm run build:prod",
     "lint": "eslint src/*",
     "lint:fix": "npm run lint -- --fix",
     "docs": "jsdoc src/pathfora.js -d docs",


### PR DESCRIPTION
Currently, with the added instrumentation for code coverage, the PathforaJS code built in the `./dist` folder is wrapped in istanbul instrumentation. 

This PR seeks to alleviate the issue by:

- Removing istanbul coverage in code when `NODE_ENV` is set to `production`.
- Added some useful npm scripts to help with Travis CI.
