### PR TITLE
Add globalReset function to cleanup tests

### DIFF
--- a/test/acceptance/ab-testing.spec.js
+++ b/test/acceptance/ab-testing.spec.js
@@ -1,12 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 // A/B TESTING
 // -------------------------
 describe('when performing AB testing', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should select only one A/B Test group to show', function () {

--- a/test/acceptance/content-recommendation.spec.js
+++ b/test/acceptance/content-recommendation.spec.js
@@ -1,23 +1,16 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  CONTENT RECOMMENDATIONS
 // -------------------------
 describe('the content recommendation component', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
     jasmine.Ajax.install();
-    window.lio = {};
-    window.pathfora.dateOptions = {};
-    pathfora.clearAll();
   });
 
   afterEach(function () {
-    window.lio = {};
-    window.liosetup = {};
     jasmine.Ajax.uninstall();
-    window.pathfora.dateOptions = {};
-    window.pathfora.acctid = '';
   });
 
   it('should handle defaults', function (done) {
@@ -254,8 +247,6 @@ describe('the content recommendation component', function () {
           'url("http://images.all-free-download.com/images/graphiclarge/blue_envelope_icon_vector_281117.jpg")'
         );
 
-        pathfora.clearAll();
-        pathfora.acctid = '';
         done();
       }, 200);
     }, 100);

--- a/test/acceptance/display-conditions-legacy.spec.js
+++ b/test/acceptance/display-conditions-legacy.spec.js
@@ -1,13 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  DISPLAY CONDITIONS LEGACY
 // -------------------------
 describe('when setting display conditions', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.clearAll();
-    sessionStorage.clear();
+    globalReset();
   });
 
   it('should show if before limited amount of impressions', function () {

--- a/test/acceptance/display-conditions.spec.js
+++ b/test/acceptance/display-conditions.spec.js
@@ -1,4 +1,4 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  DISPLAY CONDITIONS
@@ -34,9 +34,7 @@ function makeMouseEvent (type, params) {
 
 describe('when setting display conditions', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.clearAll();
-    sessionStorage.clear();
+    globalReset();
   });
 
   it('should show when all manualTrigger widgets are triggered', function () {

--- a/test/acceptance/entity-template.spec.js
+++ b/test/acceptance/entity-template.spec.js
@@ -1,12 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  ENTITY FIELD TEMPLATES
 // -------------------------
 describe('the entity templates', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should replace dynamic templates with entity fields', function (done) {

--- a/test/acceptance/gate.spec.js
+++ b/test/acceptance/gate.spec.js
@@ -1,11 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  GATE
 // -------------------------
 describe('the gate component', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   it('should open gate when the cookie is not set', function (done) {

--- a/test/acceptance/pathfora.spec.js
+++ b/test/acceptance/pathfora.spec.js
@@ -1,12 +1,7 @@
 import createAndDispatchKeydown from '../utils/create-and-dispatch-keydown.js';
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 'use strict';
-
-resetLegacyTag();
-
-pathfora.utils.saveCookie('seerid', 123);
-pathfora.enableGA = false;
 
 // -------------------------
 // PATHFORA TESTS
@@ -14,10 +9,7 @@ pathfora.enableGA = false;
 
 describe('Pathfora', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    localStorage.clear();
-    sessionStorage.clear();
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should keep focus during a tab cycle in a modal or site gate', function (done) {
@@ -83,7 +75,7 @@ describe('Pathfora', function () {
       pathfora.initializeWidgets([delayedWidget, delayedWidget2, delayedWidget3]);
       pathfora.clearAll();
 
-      jasmine.clock().tick(40000);
+      jasmine.clock().tick(4000);
       var widget = $('#' + delayedWidget.id);
       var widget2 = $('#' + delayedWidget2.id);
       var widget3 = $('#' + delayedWidget3.id);

--- a/test/acceptance/personalization.spec.js
+++ b/test/acceptance/personalization.spec.js
@@ -1,31 +1,17 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 // INLINE PERSONALIZATION TEST
 // -------------------------
 describe('Inline Personalization', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   // -------------------------
   // TRIGGER ELEMENTS
   // -------------------------
   describe('pftrigger elements', function () {
-    beforeEach(function () {
-      window.pathfora.inline.elements = [];
-      window.pathfora.acctid = '';
-      window.pathfora.dateOptions = {};
-      pathfora.clearAll();
-    });
-
-    afterEach(function () {
-      window.pathfora.inline.elements = [];
-      window.pathfora.acctid = '';
-      window.pathfora.dateOptions = {};
-      pathfora.clearAll();
-    });
-
     it('should select to show the first matching element per group', function (done) {
       window.lio = {
         data: {
@@ -172,16 +158,12 @@ describe('Inline Personalization', function () {
   // -------------------------
   describe('pfrecommend elements', function () {
     beforeEach(function () {
-      sessionStorage.clear();
       pathfora.acctid = 123;
-      pathfora.inline.elements = [];
-      pathfora.dateOptions = {};
       jasmine.Ajax.install();
     });
 
     afterEach(function () {
       jasmine.Ajax.uninstall();
-      pathfora.dateOptions = {};
     });
 
     it('should fill pftype elements with content recommendation data', function (done) {

--- a/test/acceptance/prioritized-widgets.spec.js
+++ b/test/acceptance/prioritized-widgets.spec.js
@@ -1,17 +1,9 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // Prioritized Widget Tests
 describe('Prioritized widgets', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    localStorage.clear();
-    sessionStorage.clear();
-    pathfora.clearAll();
-    window.lio = {};
-  });
-
-  afterEach(function () {
-    window.lio = {};
+    globalReset();
   });
 
   describe('of type "ordered"', function () {

--- a/test/acceptance/scaffolding.spec.js
+++ b/test/acceptance/scaffolding.spec.js
@@ -1,14 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 // SCAFFOLDING
 // -------------------------
 describe('when building a scaffolding component', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    localStorage.clear();
-    sessionStorage.clear();
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should create an empty widget config with empty target and inverse arrays ready for construction', function () {

--- a/test/acceptance/targeting.spec.js
+++ b/test/acceptance/targeting.spec.js
@@ -1,12 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 // TARGETING
 // -------------------------
 describe('when targeting users', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should distinguish newcomers, subscribers and common users', function (done) {
@@ -82,8 +81,6 @@ describe('when targeting users', function () {
       expect(notOpenedC.length).toBe(0);
       expect(universalWidget.hasClass('opened')).toBeTruthy();
       expect(widgetB.hasClass('opened')).toBeTruthy();
-
-      pathfora.clearAll();
       done();
     }, 200);
   });
@@ -137,7 +134,6 @@ describe('when targeting users', function () {
     setTimeout(function () {
       expect(widgetB.hasClass('opened')).toBeTruthy();
       expect(widgetA.length).toBe(0);
-      pathfora.clearAll();
       done();
     }, 200);
   });
@@ -190,7 +186,6 @@ describe('when targeting users', function () {
     setTimeout(function () {
       expect(widgetA.hasClass('opened')).toBeTruthy();
       expect(widgetB.hasClass('opened')).toBeTruthy();
-      pathfora.clearAll();
       done();
     }, 200);
   });

--- a/test/acceptance/tracking.spec.js
+++ b/test/acceptance/tracking.spec.js
@@ -1,4 +1,4 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 window.ga = function () {};
 window.ga.getAll = function () {};
@@ -8,7 +8,7 @@ window.ga.getAll = function () {};
 // -------------------------
 describe('the tracking component', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
 
     var gaInstances = [
       {
@@ -27,9 +27,6 @@ describe('the tracking component', function () {
       }
     ];
 
-    localStorage.clear();
-    sessionStorage.clear();
-    pathfora.clearAll();
     spyOn(window, 'ga');
     spyOn(window.ga, 'getAll').and.returnValue(gaInstances);
     pathfora.enableGA = true;
@@ -40,8 +37,6 @@ describe('the tracking component', function () {
   });
 
   it('should know if users have interacted in the past', function () {
-    localStorage.clear();
-
     var messageBar = new pathfora.Message({
       layout: 'bar',
       id: 'interest-widget1',
@@ -134,7 +129,6 @@ describe('the tracking component', function () {
       jasmine.any(Object)
     );
 
-    pathfora.clearAll();
     jasmine.Ajax.uninstall();
   });
 
@@ -183,7 +177,6 @@ describe('the tracking component', function () {
       jasmine.any(Object)
     );
 
-    pathfora.clearAll();
     jasmine.clock().uninstall();
     jasmine.Ajax.uninstall();
   });

--- a/test/acceptance/utils.spec.js
+++ b/test/acceptance/utils.spec.js
@@ -1,11 +1,11 @@
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 // UTIL TESTS
 // -------------------------
 describe('Utils', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   describe('the escapeURI util', function () {

--- a/test/acceptance/widget.spec.js
+++ b/test/acceptance/widget.spec.js
@@ -1,15 +1,12 @@
 import createAndDispatchKeydown from '../utils/create-and-dispatch-keydown.js';
-import resetLegacyTag from '../utils/reset-legacy-tag';
+import globalReset from '../utils/global-reset';
 
 // -------------------------
 //  WIDGET TESTS
 // -------------------------
 describe('Widgets', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    localStorage.clear();
-    sessionStorage.clear();
-    pathfora.clearAll();
+    globalReset();
   });
 
   // -------------------------
@@ -104,7 +101,6 @@ describe('Widgets', function () {
 
     setTimeout(function () {
       expect(widget.hasClass('opened')).toBeTruthy();
-      pathfora.clearAll();
       done();
     }, 200);
   });
@@ -153,7 +149,6 @@ describe('Widgets', function () {
 
       setTimeout(function () {
         expect($('#' + openedWidget.id).length).toEqual(1);
-        pathfora.clearAll();
         done();
       }, 200);
     }, 500);
@@ -275,7 +270,6 @@ describe('Widgets', function () {
     };
 
     expect(missingParams).toThrow(new Error('Config object is missing'));
-    pathfora.clearAll();
   });
 
   it('should not show branding assets unless set otherwise', function () {
@@ -1090,8 +1084,6 @@ describe('Widgets', function () {
             formStatesWidget.formStates.error.cancelAction.name
         })
       );
-      pathfora.clearAll();
-
       done();
     }, 600);
   });
@@ -1305,8 +1297,6 @@ describe('Widgets', function () {
   // -------------------------
 
   it('should be able to hide and show fields based on config', function () {
-    pathfora.clearAll();
-
     var formfields = new pathfora.Form({
       id: 'sample-form',
       msg: 'subscription',

--- a/test/unit/callbacks/add-callback.spec.js
+++ b/test/unit/callbacks/add-callback.spec.js
@@ -1,9 +1,9 @@
+import globalReset from '../../utils/global-reset';
+
 describe('addCallback', function () {
   describe('when no tag found', function () {
     beforeEach(function () {
-      window.jstag = null;
-      window.lio = null;
-      pathfora.callbacks = [];
+      globalReset();
     });
 
     it('should fall back and add a callback to the callbacks array', function () {

--- a/test/unit/data/segments-get-user-segments.spec.js
+++ b/test/unit/data/segments-get-user-segments.spec.js
@@ -1,14 +1,13 @@
 import getUserSegments from '../../../src/rollup/data/segments/get-user-segments';
+import globalReset from '../../utils/global-reset';
 
 describe('getUserSegments', function () {
-  beforeEach(function () {});
+  beforeEach(function () {
+    globalReset();
+  });
+
 
   describe('when no tag is installed', function () {
-    beforeEach(function () {
-      window.lio = null;
-      window.jstag = null;
-    });
-
     it('should return default segments if nothing is installed', function () {
       var segments = getUserSegments();
       expect(segments).toEqual(['all']);
@@ -16,11 +15,6 @@ describe('getUserSegments', function () {
   });
 
   describe('when legacy tag is installed', function () {
-    beforeEach(function () {
-      window.jstag = null;
-      window.lio = {};
-    });
-
     it('should return default segments when no lio.data object', function () {
       window.lio = {};
 
@@ -66,11 +60,6 @@ describe('getUserSegments', function () {
   });
 
   describe('when current gen tag is installed', function () {
-    beforeEach(function () {
-      window.lio = null;
-      window.jstag = {};
-    });
-
     it('should return default segments when no jstag.getSegments() function', function () {
       window.jstag = {};
 

--- a/test/unit/data/segments-in-segment.spec.js
+++ b/test/unit/data/segments-in-segment.spec.js
@@ -1,9 +1,11 @@
 import inSegment from '../../../src/rollup/data/segments/in-segment';
+import globalReset from '../../utils/global-reset';
 
 describe('inSegment', function () {
   describe('when is legacy', function () {
     beforeEach(function () {
-      window.jstag = null;
+      globalReset();
+
       window.lio = {
         data: {
           segments: ['one', 'fish', 'two', 'fish']

--- a/test/unit/display-conditions/entity-fields/replace-entity-field.spec.js
+++ b/test/unit/display-conditions/entity-fields/replace-entity-field.spec.js
@@ -1,9 +1,9 @@
 import replaceEntityField from '../../../../src/rollup/display-conditions/entity-fields/replace-entity-field';
+import globalReset from '../../../utils/global-reset';
 
 describe('replaceEntityField', function () {
   beforeEach(function () {
-    window.jstag = null;
-    window.lio = null;
+    globalReset();
   });
 
   describe('when using legacy tag', function () {

--- a/test/unit/validation/validate-account-id.spec.js
+++ b/test/unit/validation/validate-account-id.spec.js
@@ -1,10 +1,9 @@
-import resetLegacyTag from '../../utils/reset-legacy-tag';
+import globalReset from '../../utils/global-reset';
 import validateAccountId from '../../../src/rollup/validation/validate-account-id';
 
 describe('validateAccountId', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    pathfora.acctid = '';
+    globalReset();
   });
 
   describe('when no tag is installed', function () {

--- a/test/unit/validation/validate-options.spec.js
+++ b/test/unit/validation/validate-options.spec.js
@@ -1,14 +1,13 @@
-import resetLegacyTag from '../../utils/reset-legacy-tag';
 import validateOptions from '../../../src/rollup/validation/validate-options';
+import globalReset from '../../utils/global-reset';
 
 describe('validateOptions', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   it('should throw an error priority is invalid', function () {
     var options = { priority: 'bad' };
-
     expect(function () {
       validateOptions(options);
     }).toThrow(new Error('Invalid priority defined in options.'));

--- a/test/unit/validation/validate-recommendation-widget.spec.js
+++ b/test/unit/validation/validate-recommendation-widget.spec.js
@@ -1,9 +1,9 @@
-import resetLegacyTag from '../../utils/reset-legacy-tag';
 import validateRecommendationWidget from '../../../src/rollup/validation/validate-recommendation-widget';
+import globalReset from '../../utils/global-reset';
 
 describe('validateRecommendationWidget', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   it('should throw an error it has the wrong layout type', function () {

--- a/test/unit/widgets/has/has-entity-templates.spec.js
+++ b/test/unit/widgets/has/has-entity-templates.spec.js
@@ -1,9 +1,9 @@
-import resetLegacyTag from '../../../utils/reset-legacy-tag';
 import hasEntityTemplates from '../../../../src/rollup/widgets/has/has-entity-templates';
+import globalReset from '../../../utils/global-reset';
 
 describe('hasEntityTemplates', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   it('should return true if widget has entity templates', function () {

--- a/test/unit/widgets/has/has-recommend.spec.js
+++ b/test/unit/widgets/has/has-recommend.spec.js
@@ -1,9 +1,9 @@
-import resetLegacyTag from '../../../utils/reset-legacy-tag';
 import hasRecommend from '../../../../src/rollup/widgets/has/has-recommend';
+import globalReset from '../../../utils/global-reset';
 
 describe('hasRecommend', function () {
   beforeEach(function () {
-    resetLegacyTag();
+    globalReset();
   });
 
   it('should return true if widget has the recommend setting', function () {

--- a/test/unit/widgets/preload-lio.spec.js
+++ b/test/unit/widgets/preload-lio.spec.js
@@ -1,11 +1,9 @@
-import resetLegacyTag from '../../utils/reset-legacy-tag';
+import globalReset from '../../utils/global-reset';
 import preloadLio from '../../../src/rollup/widgets/preload-lio';
 
 describe('preloadLio', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    window.lio = {};
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should execute the callback immediately if lio is not needed', function (done) {

--- a/test/unit/widgets/recommendations/preload-recommendation.spec.js
+++ b/test/unit/widgets/recommendations/preload-recommendation.spec.js
@@ -1,11 +1,9 @@
-import resetLegacyTag from '../../../utils/reset-legacy-tag';
+import globalReset from '../../../utils/global-reset';
 import preloadRecommendation from '../../../../src/rollup/widgets/recommendations/preload-recommendation';
 
 describe('preloadRecommendation', function () {
   beforeEach(function () {
-    resetLegacyTag();
-    window.lio = {};
-    pathfora.clearAll();
+    globalReset();
   });
 
   it('should execute the callback immediately if recommendation is not needed', function () {

--- a/test/utils/global-reset.js
+++ b/test/utils/global-reset.js
@@ -1,0 +1,25 @@
+export default function globalReset () {
+  // reset jstag
+  window.jstag = {
+    send: function () {},
+    config: {
+      cookie: 'seerid'
+    }
+  };
+  window.lio = {};
+  window.liosetup = {};
+
+  // reset pathfora
+  window.pathfora.dateOptions = {};
+  window.pathfora.acctid = '';
+  window.pathfora.enableGA = false;
+  window.pathfora.inline.elements = [];
+  window.pathfora.callbacks = [];
+  window.pathfora.clearAll();
+
+  // reset storage
+  document.cookie = '';
+  window.pathfora.utils.saveCookie('seerid', 123);
+  sessionStorage.clear();
+  localStorage.clear();
+}

--- a/test/utils/reset-legacy-tag.js
+++ b/test/utils/reset-legacy-tag.js
@@ -1,8 +1,0 @@
-export default function resetLegacyTag () {
-  window.jstag = {
-    send: function () {},
-    config: {
-      cookie: 'seerid'
-    }
-  };
-}


### PR DESCRIPTION
Fixes some of the random test failures we were seeing in 1.1.5. This forces a bunch of things to be cleared and reset before each test is run.