### PR TITLE
Fix broken docs links on lytics.github.io/pathforadocs

### DIFF
--- a/docs/docs/ab_testing.md
+++ b/docs/docs/ab_testing.md
@@ -17,7 +17,7 @@ pathfora.initializeWidgets([moduleA]);
 
 ## ABTest
 
-Pathfora has a special configuration method for A/B Testing. This configuration is then used as a parameter for [initializeABTesting](/api/methods/#initializeabtesting).
+Pathfora has a special configuration method for A/B Testing. This configuration is then used as a parameter for [initializeABTesting](../api/methods/#initializeabtesting).
 
 <table>
   <thead>
@@ -61,7 +61,7 @@ In the example below roughly half of all users will be shown a gated form (A) an
 
 
 ## With Audience Targeting
-A/B Testing can be combined with [audience targeting](targeting) to divide an audience into a 50/50 split. 
+A/B Testing can be combined with [audience targeting](../targeting) to divide an audience into a 50/50 split. 
 
 In the example below module "A" will be displayed to roughly half of the users in the `smt_new` audience, while the other half of the audience will be shown module "B".
 

--- a/docs/docs/api/config.md
+++ b/docs/docs/api/config.md
@@ -1,4 +1,4 @@
-For multiple modules with common elements we can define a configuration to apply to all modules, or all modules of a certain type. Maintaining a common config helps reduce the code repitition and allows you to change settings accross many widgets in one place. A config object can be passed as a second, optional argument to [initializeWidgets](/api/methods#initializewidgets).
+For multiple modules with common elements we can define a configuration to apply to all modules, or all modules of a certain type. Maintaining a common config helps reduce the code repitition and allows you to change settings accross many widgets in one place. A config object can be passed as a second, optional argument to [initializeWidgets](../methods#initializewidgets).
 
 ``` javascript
 var config = {

--- a/docs/docs/api/methods.md
+++ b/docs/docs/api/methods.md
@@ -98,10 +98,10 @@ Each module type that Pathfora supports has its own configuration method, which 
 
 We cover each of these type configuration methods and their parameters in individual type sections below.
 
-- [Message](/types/message)
-- [Form](/types/form)
-- [Subscription](/types/subscription)
-- [Gate](/types/gate)
+- [Message](../../types/message)
+- [Form](../../types/form)
+- [Subscription](../../types/subscription)
+- [Gate](../../types/gate)
 
 
 ## initializeABTesting
@@ -158,7 +158,7 @@ recommendContent is a public method that makes a request to the Lytics content r
   <tr>
     <td>params</td>
     <td>object</td>
-    <td>object containing query params to call the <a href="https://www.getlytics.com/developers/rest-api#content-recommendation">recommendation API</a> with</td>
+    <td>object containing query params to call the <a href="https://learn.lytics.com/documentation/developer/api-docs/content#content-recommendation">recommendation API</a> with</td>
   </tr>
   <tr>
     <td>id</td>
@@ -174,7 +174,7 @@ recommendContent is a public method that makes a request to the Lytics content r
 
 ## triggerWidgets
 
-triggerWidgets is a helper method for widgets with the [manualTrigger](/display_conditions#manualTrigger) displayCondition. Widgets with this condition will not display until all other display conditions are met, and  `pathora.triggerWidgets` has been called. This method similar to `initializeWidgets`, in that it is useful when you want to trigger a module on a custom event with javascript. However with `triggerWidgets` you don't need to pass in widget object thus you can call this method even before the config has been defined.
+triggerWidgets is a helper method for widgets with the [manualTrigger](../../display_conditions#manualTrigger) displayCondition. Widgets with this condition will not display until all other display conditions are met, and  `pathora.triggerWidgets` has been called. This method similar to `initializeWidgets`, in that it is useful when you want to trigger a module on a custom event with javascript. However with `triggerWidgets` you don't need to pass in widget object thus you can call this method even before the config has been defined.
 
 <table>
   <thead>

--- a/docs/docs/callbacks.md
+++ b/docs/docs/callbacks.md
@@ -1,7 +1,7 @@
 All actions taken for clicking a button, submitting a form, and other such events support optional javascript callback settings.
 
 ## confirmAction
-Set a [tracking name](/tracking) and javascript callback for a "confirm" button click event.
+Set a [tracking name](../tracking) and javascript callback for a "confirm" button click event.
 
 <table>
   <thead>
@@ -72,7 +72,7 @@ Set a [tracking name](/tracking) and javascript callback for a "confirm" button 
 <pre data-src="../examples/src/callbacks/confirmAction.js"></pre>
 
 ## cancelAction
-Set a [tracking name](/tracking) and javascript callback for a "cancel" button click event.
+Set a [tracking name](../tracking) and javascript callback for a "cancel" button click event.
 
 <table>
   <thead>
@@ -133,7 +133,7 @@ Set a [tracking name](/tracking) and javascript callback for a "cancel" button c
 <pre data-src="../examples/src/callbacks/cancelAction.js"></pre>
 
 ## closeAction
-Set a [tracking name](/tracking) and javascript callback for a "close" button click event.
+Set a [tracking name](../tracking) and javascript callback for a "close" button click event.
 
 <table>
   <thead>
@@ -256,7 +256,7 @@ Javascript callback function on loading the module, triggered when the module is
 
 
 ## onClick
-Javascript callback function **for [button layouts](/layouts/button) only** on click of the button widget.
+Javascript callback function **for [button layouts](../layouts/button) only** on click of the button widget.
 
 <table>
   <thead>

--- a/docs/docs/content_recommend.md
+++ b/docs/docs/content_recommend.md
@@ -1,6 +1,6 @@
 Instead of hand selecting content to show an audience, you can can create a module that will suggest content at a individual level, based on the viewer's content affinities in Lytics.
 
-**Note**: only [Message](/types/message) modules using a [slideout](/layouts/slideout), [modal](/layouts/modal) or [modal](/layouts/inline) layout and a [variant](/layouts/modal#variant) of `3` support content recommendations.
+**Note**: only [Message](../types/message) modules using a [slideout](../layouts/slideout), [modal](../layouts/modal) or [modal](../layouts/inline) layout and a [variant](../layouts/modal#variant) of `3` support content recommendations.
 
 ## recommend
 

--- a/docs/docs/customization/buttons.md
+++ b/docs/docs/customization/buttons.md
@@ -1,4 +1,4 @@
-Pathfora modules can have up to two action buttons "confirm" and "cancel". You can set custom text for these buttons as well as select to hide one or both of them. See the [callbacks](/callbacks) section for how to add javascript callbacks on these buttons.
+Pathfora modules can have up to two action buttons "confirm" and "cancel". You can set custom text for these buttons as well as select to hide one or both of them. See the [callbacks](../../callbacks) section for how to add javascript callbacks on these buttons.
 
 ## okShow
 

--- a/docs/docs/customization/css.md
+++ b/docs/docs/customization/css.md
@@ -1,8 +1,8 @@
-Pathfora is built to be entirely customizable for developers. With the javascript config alone you can [change the colors](/customization/themes) of any element of the module. But, to make your module fully fit the look and feel of your site you can add custom CSS.
+Pathfora is built to be entirely customizable for developers. With the javascript config alone you can [change the colors](../themes) of any element of the module. But, to make your module fully fit the look and feel of your site you can add custom CSS.
 
 ## Key Class Names
 
-The outer most `<div>` of all Pathfora modules have the `pf-widget` class. For most modules this will be the containing div surrounding the content, but for [modal](/layouts/modal) and [gate](/types/gate) modules this div will contain the full-screen overlay behind the module. `pf-widget` has a number of useful subclasses to help select modules by their settings from the javascript config.
+The outer most `<div>` of all Pathfora modules have the `pf-widget` class. For most modules this will be the containing div surrounding the content, but for [modal](../../layouts/modal) and [gate](../../types/gate) modules this div will contain the full-screen overlay behind the module. `pf-widget` has a number of useful subclasses to help select modules by their settings from the javascript config.
 
 **Subclasses of `pf-widget`:**
 
@@ -28,7 +28,7 @@ Within the `pf-widget` div most key elements are assigned class names. Form comp
 | `pf-widget-btn` | general class for all buttons |
 | `pf-widget-ok` | "Confirm" button |
 | `pf-widget-cancel` | "Cancel" button |
-| `pf-widget-img` | image element for modules of [variant 2](/layouts/modal#variant)
+| `pf-widget-img` | image element for modules of [variant 2](../../layouts/modal#variant)
 
 To see these classes in action, you can view the html [templates](https://github.com/lytics/pathforajs/tree/master/src/templates) that will be rendered on your website. This is the html that gets minified, and added to a div with the class `pf-widget`. That div then gets added to the DOM of your website.
 

--- a/docs/docs/customization/entity_fields.md
+++ b/docs/docs/customization/entity_fields.md
@@ -25,7 +25,7 @@ pathfora.customData.name = 'Jon Snow';
 
 For example, if a user submits a form on your website asking for their info and you would like to immediately use this data in a module, you can add it to the customData object before initializing the widget and use an entity field template.
 
-If the data isn't present for the user viewing the modal there are a couple options available to control the behavior of the module. By default if there is no fallback defined for the field, pathfora will prevent the module from being displayed for visitors who lack the necessary fields. This behavior can be changed with the [showOnMissingFields](/display_conditions#showonmissingfields) display condition.
+If the data isn't present for the user viewing the modal there are a couple options available to control the behavior of the module. By default if there is no fallback defined for the field, pathfora will prevent the module from being displayed for visitors who lack the necessary fields. This behavior can be changed with the [showOnMissingFields](../../display_conditions#showonmissingfields) display condition.
 
 # Defining a Fallback (default) Value
 

--- a/docs/docs/customization/form.md
+++ b/docs/docs/customization/form.md
@@ -1,8 +1,8 @@
-Pathfora now allows for fully customized form fields for modules of type [form](/types/form) and [gate](/types/form). These input fields include text, texarea, select, checkbox, and radio button.
+Pathfora now allows for fully customized form fields for modules of type [form](../../types/form) and [gate](../../types/gate). These input fields include text, texarea, select, checkbox, and radio button.
 
-Try out our [form schema builder](/customization/form_builder) to easily build forms with a drag and drop interface and output a `formElements` object for your module config.
+Try out our [form schema builder](../form_builder) to easily build forms with a drag and drop interface and output a `formElements` object for your module config.
 
-Legacy form documentation is also available [here](/customization/form_legacy)
+Legacy form documentation is also available [here](../form_legacy)
 
 ## formElements
 

--- a/docs/docs/customization/form_legacy.md
+++ b/docs/docs/customization/form_legacy.md
@@ -1,8 +1,8 @@
-Pathfora now supports fully customizable [form elements](/types/form). This doc outlines the customization options for deprecated forms including hiding specific input fields, setting placeholder text, and selecting which fields are required for the user to submit the form.
+Pathfora now supports fully customizable [form elements](../../types/form). This doc outlines the customization options for deprecated forms including hiding specific input fields, setting placeholder text, and selecting which fields are required for the user to submit the form.
 
 ## fields
 
-Select which fields should be a part of the module's form. By default, a [form](/types/form) module has the name, email, title, and message fields. And a [gate](/types/form) module has the name, email, company, and title fields. 
+Select which fields should be a part of the module's form. By default, a [form](../../types/form) module has the name, email, title, and message fields. And a [gate](../../types/form) module has the name, email, company, and title fields. 
 
 <table>
   <thead>

--- a/docs/docs/customization/responsive.md
+++ b/docs/docs/customization/responsive.md
@@ -1,4 +1,4 @@
-By default, all Pathfora modules have a responsive design which will scale for screen size and device. Larger modules such as [gate](/types/gate) or [modals](/layouts/modal) will likely take up the full screen space on a mobile device. Smaller modules such as [bar](/layouts/bar) and [slideout](/layouts/slideout) will fit completely within a mobile screen if the content is short enough, and scroll otherwise. The responsive behavior can be turned off if you would not like to show your modules on smaller screen sizes.
+By default, all Pathfora modules have a responsive design which will scale for screen size and device. Larger modules such as [gate](../../types/gate) or [modals](../../layouts/modal) will likely take up the full screen space on a mobile device. Smaller modules such as [bar](../../layouts/bar) and [slideout](../../layouts/slideout) will fit completely within a mobile screen if the content is short enough, and scroll otherwise. The responsive behavior can be turned off if you would not like to show your modules on smaller screen sizes.
 
 ## responsive
 

--- a/docs/docs/customization/themes.md
+++ b/docs/docs/customization/themes.md
@@ -1,4 +1,4 @@
-Pathfora has two basic built-in color themes: light (default if no theme is set) and dark. Furthermore, the user can set their own custom colors for any element of the module within the javascript configuration. For more advanced color and style customization you can [add your own CSS](/customization/css).
+Pathfora has two basic built-in color themes: light (default if no theme is set) and dark. Furthermore, the user can set their own custom colors for any element of the module within the javascript configuration. For more advanced color and style customization you can [add your own CSS](../../customization/css).
 
 ## theme
 Set the color scheme of the module. This can be a predefined theme or indicate that the module should have custom colors.

--- a/docs/docs/display_conditions.md
+++ b/docs/docs/display_conditions.md
@@ -82,7 +82,7 @@ displayConditions: {
 ```
 
 ## showOnMissingFields
-By default, a module will be hidden if tried to include an [entity field](customization/entity_fields) that the user does not have. showOnMissingFields can override this beahvior.
+By default, a module will be hidden if tried to include an [entity field](../customization/entity_fields) that the user does not have. showOnMissingFields can override this beahvior.
 
 <table>
   <thead>
@@ -539,7 +539,7 @@ displayConditions: {
 
 ## manualTrigger
 
-Control when a module is triggered with javascript. Use this displayCondition in conjunction with the [triggerWidgets](api/methods#triggerWidgets).
+Control when a module is triggered with javascript. Use this displayCondition in conjunction with the [triggerWidgets](../api/methods#triggerWidgets).
 
 <table>
   <thead>

--- a/docs/docs/layouts/inline.md
+++ b/docs/docs/layouts/inline.md
@@ -1,6 +1,6 @@
 An inline module can be inserted into an existing `<div>` element on your page. This allows you to render personalized messages and forms anywhere on your page.
 
-**Note:** inline modules do not support the close or cancel option. Clicking the confirm button will trigger [success state](/customization/form#success) for form or subscription modules, but we recommend setting a [custom callback](/callbacks) for the confirm button of a inline message module.
+**Note:** inline modules do not support the close or cancel option. Clicking the confirm button will trigger [success state](../../customization/form#success) for form or subscription modules, but we recommend setting a [custom callback](../../callbacks) for the confirm button of a inline message module.
 
 ## position
 

--- a/docs/docs/targeting.md
+++ b/docs/docs/targeting.md
@@ -1,4 +1,4 @@
-Pathfora gains power by seamlessly integrating with [Lytics](http://www.getlytics.com/) for real-time user identification. This allows for precise audience targeting with each module. Setting this up in Pathfora requires an object with certain targeting rules as the first parameter to [initializeWidgets](/api/methods#initializewidgets).
+Pathfora gains power by seamlessly integrating with [Lytics](http://www.getlytics.com/) for real-time user identification. This allows for precise audience targeting with each module. Setting this up in Pathfora requires an object with certain targeting rules as the first parameter to [initializeWidgets](../api/methods#initializewidgets).
 
 ``` javascript
 var modules = {

--- a/docs/docs/tracking.md
+++ b/docs/docs/tracking.md
@@ -10,7 +10,7 @@ As long as your [Lytics JavaScript tag](https://learn.lytics.com/understanding/p
 | `pf-widget-layout` | string | layout of the module |
 | `pf-widget-variant` | int | variant of the module |
 | `pf-widget-event` | string | name of the event (see below) |
-| `pf-widget-action` | string | custom tracking names for button click events as defined in [confirmAction](/callbacks/#confirmaction) or [cancelAction](/callbacks/#cancelaction) |
+| `pf-widget-action` | string | custom tracking names for button click events as defined in [confirmAction](../callbacks/#confirmaction) or [cancelAction](../callbacks/#cancelaction) |
 | `pf-form-username` | string | user submitted value of "name" field on module |
 | `pf-form-title` | string | user submitted value of "title" field on module |
 | `pf-form-email` | string | user submitted value of "email" field on module |
@@ -90,4 +90,4 @@ If this flag is enabled, pathfora will send event data from the modules on your 
 | eventCategory | string | Lytics |
 | eventAction | string | [id of module] : [event name] |
 
-The `[event name]` signifier in eventAction will match the event names for the `pf-widget-event` field [sent to Lytics](#lytics). However, if you've defined custom names in the [confirmAction](/callbacks/#confirmaction) or [cancelAction](/callbacks/#cancelaction) settings this will override the event name for those actions.
+The `[event name]` signifier in eventAction will match the event names for the `pf-widget-event` field [sent to Lytics](#lytics). However, if you've defined custom names in the [confirmAction](../callbacks/#confirmaction) or [cancelAction](../callbacks/#cancelaction) settings this will override the event name for those actions.


### PR DESCRIPTION
The docs link fix contained in
https://github.com/lytics/pathforajs/pull/427 didn't actually solve the
problem, but it wasn't apparent until we attempted to publish docs.

This commit fixes internal docs links to lytics.github.io/pathforadocs