### PR TITLE
feat: censorTrackingKeys config option

### DIFF
--- a/docs/docs/tracking.md
+++ b/docs/docs/tracking.md
@@ -1,5 +1,38 @@
 Pathfora can send tracking events and the user data submitted to Lytics and Google Analytics. As long as your tags are all set up in the correct order, module data will be sent Lytics automatically. Below we will look at which data fields are sent in detail and their formats.
 
+## censorTrackingKeys
+
+This option exposes the capability to censor keys from payloads sent into Lytics. Any keys included as strings, or matching patterns as regular expressions that should be omitted from all payloads.
+
+<table>
+  <thead>
+    <tr>
+      <td colspan="2" align="center"><code>censorTrackingKeys</code>  array of string and/or regular expressions</td>
+    </tr>
+    <tr>
+      <th>Value</th>
+      <th>Behavior</th>
+    </tr>
+  </thead>
+
+  <tr>
+    <td>array of strings</td>
+    <td>keys which match any of the strings exactly will be censored from any payloads sent to Lytics</td>
+  </tr>
+  <tr>
+    <td>array of regular expressions</td>
+    <td>any key which matches any of the regular expression patterns will be censored from any payloads sent to Lytics</td>
+  </tr>
+</table>
+
+``` javascript
+// help ensure compliance with industry-specific PII regulations by censoring form data,
+var widget = new pathfora.Form({
+  // other configuration options elided
+  censorTrackingKeys: [/pf-form/]
+});
+```
+
 ## Lytics
 As long as your [Lytics JavaScript tag](https://learn.lytics.com/understanding/product-docs/lytics-javascript-tag/configuration) is loaded before the Pathfora tag, all event data and data collected from modules with user input will be sent to the the stream [configured in your Lytics JavaScript tag](https://learn.lytics.com/understanding/product-docs/lytics-javascript-tag/configuration). The following raw data fields can be sent to Lytics by Pathfora.
 
@@ -29,7 +62,7 @@ As long as your [Lytics JavaScript tag](https://learn.lytics.com/understanding/p
       <th>Behavior</th>
     </tr>
   </thead>
-  
+
   <tr>
     <td>show</td>
     <td>module was displayed to the user</td>

--- a/src/rollup/data/request/report-data.js
+++ b/src/rollup/data/request/report-data.js
@@ -1,18 +1,24 @@
 /** @module pathfora/data/request/report-data */
 
 import window from '../../dom/window';
+import censorTrackingKeys from '../../utils/censor-tracking-keys';
 
 /**
  * Send data object to Lytics and GA
  *
  * @exports reportData
  * @params {object} data
+ * @widget {object}
  */
-export default function reportData (data) {
+export default function reportData (data, widget) {
   var gaLabel, trackers;
 
   if (typeof jstag === 'object') {
-    window.jstag.send(data);
+    window.jstag.send(
+      widget.censorTrackingKeys
+        ? censorTrackingKeys(data, widget.censorTrackingKeys)
+        : data
+    );
   } else {
     // NOTE Cannot find Lytics tag, reporting disabled
   }

--- a/src/rollup/data/tracking/track-widget-action.js
+++ b/src/rollup/data/tracking/track-widget-action.js
@@ -154,5 +154,5 @@ export default function trackWidgetAction (action, widget, htmlElement) {
   }
 
   params['pf-widget-event'] = action;
-  reportData(params);
+  reportData(params, widget);
 }

--- a/src/rollup/utils/censor-tracking-keys.js
+++ b/src/rollup/utils/censor-tracking-keys.js
@@ -1,0 +1,21 @@
+/**
+ * Censor an object by its keys, by comparing against an array of strings and/or regexps. In the case of strings,
+ * only exact matches are censored. For non-strings, if the object's test method returns true, the key will be censored.
+ *
+ * @param {object} data the data to censor
+ * @param {obejct} keysToReject an array of strings or regexps to censor the data by preparatory to sending
+ */
+export default function censorTrackingKeys (data, keysToReject) {
+  return Object.keys(data)
+    .filter(function (key) {
+      return !keysToReject.some(function (keyToReject) {
+        return typeof keyToReject === 'string'
+          ? key === keyToReject
+          : keyToReject.test(key);
+      });
+    })
+    .reduce(function (memo, key) {
+      memo[key] = data[key];
+      return memo;
+    }, {});
+}

--- a/test/acceptance/tracking.spec.js
+++ b/test/acceptance/tracking.spec.js
@@ -511,4 +511,40 @@ describe('the tracking component', function () {
 
     jasmine.Ajax.uninstall();
   });
+
+  it('should call censorTrackingKeys with widget.censorTrackingKeys when defined', function (done) {
+    var formModal = new pathfora.Form({
+      layout: 'modal',
+      id: 'tracking-widget-censored',
+      msg: 'Form modal - report test',
+      censorTrackingKeys: [/pf-form-/]
+    });
+
+    pathfora.initializeWidgets([formModal]);
+
+    var widget = $('#' + formModal.id);
+
+    setTimeout(function () {
+      var form = widget.find('form');
+      form.find('input[type=text]').val('test');
+      form.find('input[name~=email]').val('webmaster@example.com');
+
+      spyOn(jstag, 'send');
+      form.find('button[type=submit]').click();
+
+      setTimeout(function () {
+        expect(jstag.send).toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            'pf-widget-event': 'submit'
+          })
+        );
+        expect(jstag.send).not.toHaveBeenCalledWith(
+          jasmine.objectContaining({
+            'pf-form-email': 'webmaster@example.com'
+          })
+        );
+        done();
+      }, 100);
+    }, 200);
+  });
 });

--- a/test/unit/utils/censor-tracking-keys.spec.js
+++ b/test/unit/utils/censor-tracking-keys.spec.js
@@ -1,0 +1,50 @@
+import censorTrackingKeys from '../../../src/rollup/utils/censor-tracking-keys';
+
+describe('the censorTrackingKeys utility', function () {
+  it('should censor by strings using exact match semantics', function () {
+    expect(censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, ['foo'])).toEqual({
+      foobar: 2,
+      bar: 3
+    });
+  });
+
+  it('should censor by regular expression', function () {
+    expect(censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, [/foo/])).toEqual({
+      bar: 3
+    });
+  });
+
+  it("should censor by regular expression by delegating to that object's test method", function () {
+    var regexp = /foo/;
+    spyOn(regexp, 'test');
+    censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, [regexp]);
+    expect(regexp.test).toHaveBeenCalledTimes(3);
+    expect(regexp.test).toHaveBeenCalledWith('foo');
+    expect(regexp.test).toHaveBeenCalledWith('foobar');
+    expect(regexp.test).toHaveBeenCalledWith('bar');
+  });
+
+  it('should handle censor by multiple strings', function () {
+    expect(
+      censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, ['foo', 'bar'])
+    ).toEqual({
+      foobar: 2
+    });
+  });
+
+  it('should censor by multiple regular expressions', function () {
+    expect(
+      censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, [/oob/, /ar/])
+    ).toEqual({
+      foo: 1
+    });
+  });
+
+  it('should censor by a mix of strings and regexps', function () {
+    expect(
+      censorTrackingKeys({ foo: 1, foobar: 2, bar: 3 }, [/oob/, 'bar'])
+    ).toEqual({
+      foo: 1
+    });
+  });
+});


### PR DESCRIPTION
Closes #531 

This PR adds a new config option `censorTrackingKeys` which takes an array containing either strings or regular expressions. When strings are used, an exact match is tested for. Otherwise, we use regular expression semantics. This can be used to censor PII in modals, for example:

```javascript
var widget = pathfora.Form({
  // .. elided
  censorTrackingKeys: [/pf-form-/, /pf-custom-form-/]
});
```

## manual testing note

this is a suffient mock for jsatg for testing this PR:

```javascript
window.jstag = {send: console.log}
```