### PR TITLE
feat: allow PathforaCSS to come from outside

### DIFF
--- a/src/rollup/pathfora.js
+++ b/src/rollup/pathfora.js
@@ -122,7 +122,7 @@ var Pathfora = function () {
 
   link.setAttribute('rel', 'stylesheet');
   link.setAttribute('type', 'text/css');
-  link.setAttribute('href', CSS_URL);
+  link.setAttribute('href', window.PathforaCSS || CSS_URL);
 
   this.utils.updateLegacyCookies();
   this.utils.store.removeExpiredItems();


### PR DESCRIPTION
this PR lets the user configure the URL to use for the pathfora css file by defining the global `PathforaCSS` before loading this `pathfora.min.js`